### PR TITLE
Support scenario parameter of the recommendation requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Afterwards, you can get a list of recommended pages based on the contact's previ
 ```c#
 // Gets a collection of 'PageIdentifier' objects, 
 // containing the identifiers of Xperience pages recommended for the specified contact
-contentService.GetPagesRecommendationForContact(string siteName, Guid contactGuid, int count, string culture, IEnumerable<string> pageTypes = null);
+contentService.GetPagesRecommendationForContact(string siteName, Guid contactGuid, int count, string culture, IEnumerable<string> pageTypes = null, string scenario = null);
 ```
 Use the data to display a list of recommendation on your website.
 
@@ -145,7 +145,7 @@ public void ExampleMethod()
 
     // Gets a collection of 'PageIdentifier' objects, 
     // containing the identifiers of Xperience pages recommended for the specified page and contact
-    contentService.GetPagesRecommendationForPage(TreeNode page, Guid contactGuid, int count, string culture, IEnumerable<string> pageTypes = null);
+    contentService.GetPagesRecommendationForPage(TreeNode page, Guid contactGuid, int count, string culture, IEnumerable<string> pageTypes = null, string scenario = null);
 }
 ```
 

--- a/src/Kentico.Xperience.Recombee/ContentService.cs
+++ b/src/Kentico.Xperience.Recombee/ContentService.cs
@@ -38,16 +38,17 @@ namespace Kentico.Xperience.Recombee
         /// <param name="count">Number of items to return.</param>
         /// <param name="culture">Culture to be considered for recommendation.</param>
         /// <param name="pageTypes">Constrain on page types to be considered for recommendation, or null.</param>
+        /// <param name="scenario">Scenario defines a particular application of recommendations. It can be for example "homepage", "related" or "emailing". You can configure each scenario in the Recombee Admin UI.</param>
         /// <returns>Returns an enumeration of identifiers of recommended pages.</returns>
         /// <exception cref="InvalidOperationException">Thrown when the Recombee client service is not configured for <paramref name="siteName"/>.</exception>
-        public IEnumerable<PageIdentifier> GetPagesRecommendationForContact(string siteName, Guid contactGuid, int count, string culture, IEnumerable<string> pageTypes = null)
+        public IEnumerable<PageIdentifier> GetPagesRecommendationForContact(string siteName, Guid contactGuid, int count, string culture, IEnumerable<string> pageTypes = null, string scenario = null)
         {
             var client = GetClientServiceOrThrow(siteName);
             var pageTypeFilter = (pageTypes != null) ? GetPageTypeFilter(pageTypes) : null;
             var cultureFilter = (culture != null) ? GetCultureFilter(culture) : null;
             var filter = ConcatFilterExpressions(pageTypeFilter, cultureFilter);
 
-            var recommendation = client.Execute(rc => rc.Send(new RecommendItemsToUser(contactGuid.ToString(), count, filter: filter, cascadeCreate: true)));
+            var recommendation = client.Execute(rc => rc.Send(new RecommendItemsToUser(contactGuid.ToString(), count, filter: filter, cascadeCreate: true, scenario: scenario)));
 
             return recommendation.Recomms.Select(r => ParseItemId(r.Id));
         }
@@ -61,16 +62,17 @@ namespace Kentico.Xperience.Recombee
         /// <param name="count">Number of items to return.</param>
         /// <param name="cultures">Culture to be considered for recommendation.</param>
         /// <param name="pageTypes">Constrain on page types to be considered for recommendation, or null.</param>
+        /// <param name="scenario">Scenario defines a particular application of recommendations. It can be for example "homepage", "related" or "emailing". You can configure each scenario in the Recombee Admin UI.</param>
         /// <returns>Returns an enumeration of identifiers of recommended pages.</returns>
         /// <exception cref="InvalidOperationException">Thrown when the Recombee client service is not configured for <paramref name="siteName"/>.</exception>
-        public IEnumerable<PageIdentifier> GetPagesRecommendationForPage(TreeNode page, Guid contactGuid, int count, string culture, IEnumerable<string> pageTypes = null)
+        public IEnumerable<PageIdentifier> GetPagesRecommendationForPage(TreeNode page, Guid contactGuid, int count, string culture, IEnumerable<string> pageTypes = null, string scenario = null)
         {
             var client = GetClientServiceOrThrow(page.NodeSiteName);
             var pageTypeFilter = (pageTypes != null) ? GetPageTypeFilter(pageTypes) : null;
             var cultureFilter = (culture != null) ? GetCultureFilter(culture) : null;
             var filter = ConcatFilterExpressions(pageTypeFilter, cultureFilter);
 
-            var recommendation = client.Execute(rc => rc.Send(new RecommendItemsToItem(GetItemId(page), contactGuid.ToString(), count, filter: filter, cascadeCreate: true)));
+            var recommendation = client.Execute(rc => rc.Send(new RecommendItemsToItem(GetItemId(page), contactGuid.ToString(), count, filter: filter, cascadeCreate: true, scenario: scenario)));
 
             return recommendation.Recomms.Select(r => ParseItemId(r.Id));
         }

--- a/src/Kentico.Xperience.Recombee/IContentService.cs
+++ b/src/Kentico.Xperience.Recombee/IContentService.cs
@@ -24,9 +24,10 @@ namespace Kentico.Xperience.Recombee
         /// <param name="count">Number of items to return.</param>
         /// <param name="cultures">Culture to be considered for recommendation.</param>
         /// <param name="pageTypes">Constrain on page types to be considered for recommendation, or null.</param>
+        /// <param name="scenario">Scenario defines a particular application of recommendations. It can be for example "homepage", "related" or "emailing". You can configure each scenario in the Recombee Admin UI.</param>
         /// <returns>Returns an enumeration of identifiers of recommended pages.</returns>
         /// <exception cref="InvalidOperationException">Thrown when the Recombee client service is not configured for <paramref name="siteName"/>.</exception>
-        IEnumerable<PageIdentifier> GetPagesRecommendationForContact(string siteName, Guid contactGuid, int count, string culture, IEnumerable<string> pageTypes = null);
+        IEnumerable<PageIdentifier> GetPagesRecommendationForContact(string siteName, Guid contactGuid, int count, string culture, IEnumerable<string> pageTypes = null, string scenario = null);
 
 
         /// <summary>
@@ -37,9 +38,10 @@ namespace Kentico.Xperience.Recombee
         /// <param name="count">Number of items to return.</param>
         /// <param name="cultures">Culture to be considered for recommendation.</param>
         /// <param name="pageTypes">Constrain on page types to be considered for recommendation, or null.</param>
+        /// <param name="scenario">Scenario defines a particular application of recommendations. It can be for example "homepage", "related" or "emailing". You can configure each scenario in the Recombee Admin UI.</param>
         /// <returns>Returns an enumeration of identifiers of recommended pages.</returns>
         /// <exception cref="InvalidOperationException">Thrown when the Recombee client service is not configured for <paramref name="siteName"/>.</exception>
-        IEnumerable<PageIdentifier> GetPagesRecommendationForPage(TreeNode page, Guid contactGuid, int count, string culture, IEnumerable<string> pageTypes = null);
+        IEnumerable<PageIdentifier> GetPagesRecommendationForPage(TreeNode page, Guid contactGuid, int count, string culture, IEnumerable<string> pageTypes = null, string scenario = null);
 
 
         /// <summary>


### PR DESCRIPTION
Adds support for setting the `scenario` parameter of the recommendation requests (see https://docs.recombee.com/api.html#recommend-items-to-user and https://docs.recombee.com/api.html#recommend-items-to-item).

Each scenario can be configured in the Recombee Admin UI (admin.recombee.com), which adds many new possibilities for the integration. See https://docs.recombee.com/scenarios.html for details.